### PR TITLE
fix missing option in getopt

### DIFF
--- a/DiskArbitrationAgent/DiskArbitrationAgent.m
+++ b/DiskArbitrationAgent/DiskArbitrationAgent.m
@@ -193,7 +193,7 @@ int main( int argc, char * argv[], char * envp[] )
      * Process arguments.
      */
     
-    while ( ( option = getopt( argc, argv, "s" ) ) != -1 )
+    while ( ( option = getopt( argc, argv, "su" ) ) != -1 )
     {
         switch ( option )
         {


### PR DESCRIPTION
There's a small issue, when using -u as an option. It says: illegal option.

The `u` is missing in the getopt string....
